### PR TITLE
Wrong value was being used for the last press timestamp.

### DIFF
--- a/devicetypes/a4refillpad/xiaomi-zigbee-button.src/xiaomi-zigbee-button.groovy
+++ b/devicetypes/a4refillpad/xiaomi-zigbee-button.src/xiaomi-zigbee-button.groovy
@@ -174,7 +174,7 @@ private Map parseCustomMessage(String description) {
 //this method determines if a press should count as a push or a hold and returns the relevant event type
 private createButtonEvent(button) {
 	def currentTime = now()
-    def startOfPress = device.latestState('lastPress').date.getTime()
+    def startOfPress = Long.parseLong(device.latestState('lastPress').value)
     def timeDif = currentTime - startOfPress
     def holdTimeMillisec = (settings.holdTime?:3).toInteger() * 1000
     


### PR DESCRIPTION
The "date" property returned with latestState() appears to be the cassandra column timestamp. "value" is the actual value but it's stored as a string and must be cast back to Long.